### PR TITLE
optional ability to run the installed exe post-installation

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -62,7 +62,7 @@ var opts = require("nomnom")
 
     'runAfter': {
       abbr: 'r',
-      flag: true
+	flag: true,
       full: 'run-after',
       help: 'Run the application after installation completes'
     },

--- a/cli.js
+++ b/cli.js
@@ -62,6 +62,7 @@ var opts = require("nomnom")
 
     'runAfter': {
       abbr: 'r',
+      flag: true
       full: 'run-after',
       help: 'Run the application after installation completes'
     },

--- a/cli.js
+++ b/cli.js
@@ -60,6 +60,12 @@ var opts = require("nomnom")
       required: true
     },
 
+    'runAfter': {
+      abbr: 'r',
+      full: 'run-after',
+      help: 'Run the application after installation completes'
+    },
+
     'localInstall': {
       flag: true,
       full: 'local',

--- a/generate-xml.js
+++ b/generate-xml.js
@@ -47,14 +47,27 @@ function installerFor (components, options) {
         })
       ]),
 
+      options.runAfter ? el('Property', {
+	Id: "cmd",
+	Value: "cmd.exe"
+      }) : "",
+
+      options.runAfter ? el('CustomAction', {
+	  Id: "LaunchApplication",
+	  ExeCommand: "/c start \"\" \"C:\\Program Files\\"+options.name+"\\"+options.executable+"\"",
+	  Execute: "",
+	  Property: "cmd",
+	  Impersonate: "yes"
+      }) : "",
+
       el('InstallExecuteSequence', [
         el('RemoveExistingProducts', {
           Before: "InstallInitialize" 
         }),
 	options.runAfter ? el('Custom', {
-	  Action: 'LaunchInstalledExe',
+	  Action: 'LaunchApplication',
 	  After: 'InstallFinalize'
-	}) : ""
+	}, ["NOT Installed"]) : ""
       ]),
 
       el('CustomAction', {

--- a/generate-xml.js
+++ b/generate-xml.js
@@ -50,8 +50,21 @@ function installerFor (components, options) {
       el('InstallExecuteSequence', [
         el('RemoveExistingProducts', {
           Before: "InstallInitialize" 
-        })
+        }),
+	options.runAfter ? el('Custom', {
+	  Action: 'LaunchInstalledExe',
+	  After: 'InstallFinalize'
+	}) : ()
       ]),
+
+      el('CustomAction', {
+	Id: "LaunchInstalledExe",
+	FileKey: "mainExecutableFile", // what goes here?
+	ExeCommand: "",                // and here?
+	Execute: "immediate",
+	Impersonate: "yes",
+	Return: "asyncNoWait"
+      }),
 
       el('Package', {
         InstallerVersion: "200",

--- a/generate-xml.js
+++ b/generate-xml.js
@@ -54,7 +54,7 @@ function installerFor (components, options) {
 	options.runAfter ? el('Custom', {
 	  Action: 'LaunchInstalledExe',
 	  After: 'InstallFinalize'
-	}) : ()
+	}) : ""
       ]),
 
       el('CustomAction', {

--- a/generate-xml.js
+++ b/generate-xml.js
@@ -54,7 +54,7 @@ function installerFor (components, options) {
 
       options.runAfter ? el('CustomAction', {
 	  Id: "LaunchApplication",
-	  ExeCommand: "/c start \"\" \"C:\\Program Files\\"+options.name+"\\"+options.executable+"\"",
+	  ExeCommand: "/c start \"\" \"%programfiles%\\"+options.name+"\\"+options.executable+"\"",
 	  Execute: "",
 	  Property: "cmd",
 	  Impersonate: "yes"


### PR DESCRIPTION
The ability to run the installed executable after installation is a common one - I have a workable solution here via cmd.exe /c and a conditional CustomAction.

I'd have used asyncNoWait properly and skipped cmd.exe but I couldn't get it to work as expected (and struggled with the Wixl docs).
