### PR TITLE
Fix nodejs fs module deprecation (DEP0013)

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,10 +30,13 @@ module.exports = function(options, cb) {
 function writeXml(options, cb) {
   temp.open('msi-packager', function(err, info) {
     generateXml(options, function(err, xml) {
-      fs.write(info.fd, xml)
-      fs.close(info.fd, function (err) {
+      fs.write(info.fd, xml, function(err) {
         if (err) return cb(err)
-        cb(null, info.path)
+        
+        fs.close(info.fd, function (err) {
+          if (err) return cb(err)
+          cb(null, info.path)
+        })
       })
     })
   })


### PR DESCRIPTION
This fixes "DEP0013: fs asynchronous function without callback", by calling `fs.write()` with a callback