### PR TITLE
Isolate mainExecutableFile error to runAfter

### DIFF
--- a/generate-xml.js
+++ b/generate-xml.js
@@ -48,35 +48,35 @@ function installerFor (components, options) {
       ]),
 
       options.runAfter ? el('Property', {
-	Id: "cmd",
-	Value: "cmd.exe"
+	    Id: "cmd",
+	    Value: "cmd.exe"
       }) : "",
 
       options.runAfter ? el('CustomAction', {
-	  Id: "LaunchApplication",
-	  ExeCommand: "/c start \"\" \"%programfiles%\\"+options.name+"\\"+options.executable+"\"",
-	  Execute: "",
-	  Property: "cmd",
-	  Impersonate: "yes"
+	    Id: "LaunchApplication",
+	    ExeCommand: "/c start \"\" \"%programfiles%\\"+options.name+"\\"+options.executable+"\"",
+	    Execute: "",
+	    Property: "cmd",
+	    Impersonate: "yes"
       }) : "",
 
       el('InstallExecuteSequence', [
         el('RemoveExistingProducts', {
           Before: "InstallInitialize" 
         }),
-	options.runAfter ? el('Custom', {
-	  Action: 'LaunchApplication',
-	  After: 'InstallFinalize'
-	}, ["NOT Installed"]) : ""
+	    options.runAfter ? el('Custom', {
+	      Action: 'LaunchApplication',
+	      After: 'InstallFinalize'
+	    }, ["NOT Installed"]) : ""
       ]),
 
       el('CustomAction', {
-	Id: "LaunchInstalledExe",
-	FileKey: "mainExecutableFile", // what goes here?
-	ExeCommand: "",                // and here?
-	Execute: "immediate",
-	Impersonate: "yes",
-	Return: "asyncNoWait"
+	    Id: "LaunchInstalledExe",
+	    FileKey: "mainExecutableFile", // what goes here?
+	    ExeCommand: "",                // and here?
+	    Execute: "immediate",
+	    Impersonate: "yes",
+	    Return: "asyncNoWait"
       }),
 
       el('Package', {

--- a/generate-xml.js
+++ b/generate-xml.js
@@ -70,14 +70,14 @@ function installerFor (components, options) {
 	    }, ["NOT Installed"]) : ""
       ]),
 
-      el('CustomAction', {
+      options.runAfter ? el('CustomAction', {
 	    Id: "LaunchInstalledExe",
 	    FileKey: "mainExecutableFile", // what goes here?
 	    ExeCommand: "",                // and here?
 	    Execute: "immediate",
 	    Impersonate: "yes",
 	    Return: "asyncNoWait"
-      }),
+      }) : "",
 
       el('Package', {
         InstallerVersion: "200",

--- a/generate-xml.js
+++ b/generate-xml.js
@@ -48,26 +48,26 @@ function installerFor (components, options) {
       ]),
 
       options.runAfter ? el('Property', {
-	    Id: "cmd",
-	    Value: "cmd.exe"
+        Id: "cmd",
+        Value: "cmd.exe"
       }) : "",
 
       options.runAfter ? el('CustomAction', {
-	    Id: "LaunchApplication",
-	    ExeCommand: "/c start \"\" \"%programfiles%\\"+options.name+"\\"+options.executable+"\"",
-	    Execute: "",
-	    Property: "cmd",
-	    Impersonate: "yes"
+        Id: "LaunchApplication",
+        ExeCommand: "/c start \"\" \"%programfiles%\\"+options.name+"\\"+options.executable+"\"",
+        Execute: "",
+        Property: "cmd",
+        Impersonate: "yes"
       }) : "",
 
       el('InstallExecuteSequence', [
         el('RemoveExistingProducts', {
           Before: "InstallInitialize" 
         }),
-	    options.runAfter ? el('Custom', {
-	      Action: 'LaunchApplication',
-	      After: 'InstallFinalize'
-	    }, ["NOT Installed"]) : ""
+        options.runAfter ? el('Custom', {
+          Action: 'LaunchApplication',
+          After: 'InstallFinalize'
+        }, ["NOT Installed"]) : ""
       ]),
 
       options.runAfter ? el('CustomAction', {


### PR DESCRIPTION
The CustomAction LaunchedInstalledExe refers to a FileKey for a non-existent file, mainExecutableFile. Since it's only necessary for supporting --run-after, this commit stops it being defined unless runAfter is truthy.

This is not a fix for the underlying issue! However, it isolates the problem to users of --run-after, which has other bugs that make it hard to test, so it's a good interim fix.

Also fixes some whitespace formatting that mixed tabs and spaces.

See https://github.com/mmckegg/msi-packager/issues/19 for more details.